### PR TITLE
Remove unused import

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,6 @@ const svgToDataUri = require('mini-svg-data-uri');
 const plugin = require('tailwindcss/plugin');
 const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('tailwindcss/colors');
-const { transform } = require('typescript');
 const [baseFontSize, { lineHeight: baseLineHeight }] =
     defaultTheme.fontSize.base;
 const { spacing, borderWidth, borderRadius, boxShadow } = defaultTheme;


### PR DESCRIPTION
Typescript doesn't need to be imported, it's not used anywhere.

Fixes #942.